### PR TITLE
Fix bug in Minesweeper AI safe tile detection

### DIFF
--- a/MyAI.py
+++ b/MyAI.py
@@ -152,7 +152,7 @@ class MyAI( AI ):
 								for i in range(self.__colD):
 									for j in range(self.__rowD):
 										if(self.__board[i][j] == -999):
-											self.__safeTile.add((j, j))
+											self.__safeTile.add((i, j))
 
 				#after marking all, if still have not uncovered tiles, add all to safetile set
 				#or have no clue with empty triggerTile


### PR DESCRIPTION
## Summary
- fix typo when adding a default safe tile

## Testing
- `python -m py_compile MyAI.py`

------
https://chatgpt.com/codex/tasks/task_e_68587b5c89a88320b9b65c66b8b726fa